### PR TITLE
licence(#7): PMPL-1.0 -> PMPL-1.0-or-later (owner carve-out, SPDX-only)

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PMPL-1.0
+# SPDX-License-Identifier: PMPL-1.0-or-later
 FROM gcr.io/oss-fuzz-base/base-builder-rust@sha256:73c1d5648db54100639339d411a5d192cbc8bf413ee91e843a07cf6f0e319dc7
 
 COPY . $SRC/absolute-zero

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# SPDX-License-Identifier: PMPL-1.0
+# SPDX-License-Identifier: PMPL-1.0-or-later
 cd "$SRC"/absolute-zero
 cargo +nightly fuzz build
 for target in $(cargo +nightly fuzz list); do

--- a/LICENSE-AUDIT-2026-02-05.adoc
+++ b/LICENSE-AUDIT-2026-02-05.adoc
@@ -80,7 +80,7 @@ license = "MIT OR Palimpsest-0.6"  ❌ OUTDATED
 **Source files** (mixed):
 ```rust
 // SPDX-License-Identifier: MIT OR Palimpsest-0.6  ❌ OUTDATED (some files)
-// SPDX-License-Identifier: PMPL-1.0              ✅ CORRECT (other files)
+// SPDX-License-Identifier: PMPL-1.0-or-later              ✅ CORRECT (other files)
 // SPDX-License-Identifier: PMPL-1.0-or-later    ✅ CORRECT (LICENSE)
 ```
 

--- a/fuzz/fuzz_targets/fuzz_input.rs
+++ b/fuzz/fuzz_targets/fuzz_input.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PMPL-1.0
+// SPDX-License-Identifier: PMPL-1.0-or-later
 //! Generic fuzz target for arbitrary input processing
 
 #![no_main]


### PR DESCRIPTION
4 files, SPDX-value-only. NOT a relicence. Owner-sanctioned, standards LICENCE-POLICY A8(1). Refs LICENCE-DEBT-LEDGER-2026-05-18. 🤖 Generated with [Claude Code](https://claude.com/claude-code)