### PR TITLE
fix(licence): canonicalise to PMPL-1.0-or-later per authorship check (#133)

### DIFF
--- a/proofs/coq/common/CNO.v
+++ b/proofs/coq/common/CNO.v
@@ -5,7 +5,7 @@
 
     Author: Jonathan D. A. Jewell
     Project: Absolute Zero
-    License: AGPL-3.0 / Palimpsest 0.5
+    License: PMPL-1.0-or-later
 *)
 
 Require Import Coq.Init.Nat.

--- a/proofs/coq/filesystem/FilesystemCNO.v
+++ b/proofs/coq/filesystem/FilesystemCNO.v
@@ -15,7 +15,7 @@
 
     Author: Jonathan D. A. Jewell
     Project: Absolute Zero (integrating Valence Shell)
-    License: AGPL-3.0 / Palimpsest 0.5
+    License: PMPL-1.0-or-later
 *)
 
 Require Import Coq.Lists.List.

--- a/proofs/coq/malbolge/MalbolgeCore.v
+++ b/proofs/coq/malbolge/MalbolgeCore.v
@@ -7,7 +7,7 @@
 
     Author: Jonathan D. A. Jewell
     Project: Absolute Zero
-    License: AGPL-3.0 / Palimpsest 0.5
+    License: PMPL-1.0-or-later
 *)
 
 Require Import CNO.CNO.

--- a/proofs/coq/physics/LandauerDerivation.v
+++ b/proofs/coq/physics/LandauerDerivation.v
@@ -7,7 +7,7 @@
 
     Author: Jonathan D. A. Jewell
     Project: Absolute Zero - Phase 1 Complete Derivation
-    License: AGPL-3.0 / Palimpsest 0.5
+    License: PMPL-1.0-or-later
 *)
 
 Require Import Coq.Reals.Reals.

--- a/proofs/coq/physics/StatMech.v
+++ b/proofs/coq/physics/StatMech.v
@@ -6,7 +6,7 @@
 
     Author: Jonathan D. A. Jewell
     Project: Absolute Zero
-    License: AGPL-3.0 / Palimpsest 0.5
+    License: PMPL-1.0-or-later
 *)
 
 Require Import Coq.Reals.Reals.

--- a/proofs/coq/physics/StatMech_helpers.v
+++ b/proofs/coq/physics/StatMech_helpers.v
@@ -2,6 +2,10 @@
 
     Auxiliary lemmas needed for thermodynamic CNO proofs.
     These should eventually be integrated into CNO.v.
+
+    Author: Jonathan D. A. Jewell
+    Project: Absolute Zero
+    License: PMPL-1.0-or-later
 *)
 
 Require Import CNO.

--- a/proofs/coq/quantum/QuantumCNO.v
+++ b/proofs/coq/quantum/QuantumCNO.v
@@ -12,7 +12,7 @@
 
     Author: Jonathan D. A. Jewell
     Project: Absolute Zero
-    License: AGPL-3.0 / Palimpsest 0.5
+    License: PMPL-1.0-or-later
 *)
 
 Require Import Coq.Reals.Reals.

--- a/proofs/coq/quantum/QuantumMechanicsExact.v
+++ b/proofs/coq/quantum/QuantumMechanicsExact.v
@@ -8,7 +8,7 @@
 
     Author: Jonathan D. A. Jewell
     Project: Absolute Zero - Exact Quantum Formulation
-    License: AGPL-3.0 / Palimpsest 0.5
+    License: PMPL-1.0-or-later
 *)
 
 Require Import Coq.Reals.Reals.

--- a/proofs/lean4/CNO.lean
+++ b/proofs/lean4/CNO.lean
@@ -5,7 +5,7 @@
 
    Author: Jonathan D. A. Jewell
    Project: Absolute Zero
-   License: AGPL-3.0 / Palimpsest 0.5
+   License: PMPL-1.0-or-later
 -/
 
 -- Std.Data.{List,Nat}.Basic were vestigial: Std was renamed to Batteries

--- a/proofs/lean4/CNOCategory.lean
+++ b/proofs/lean4/CNOCategory.lean
@@ -5,7 +5,7 @@
 
    Author: Jonathan D. A. Jewell
    Project: Absolute Zero
-   License: AGPL-3.0 / Palimpsest 0.5
+   License: PMPL-1.0-or-later
 -/
 
 import CNO

--- a/proofs/lean4/FilesystemCNO.lean
+++ b/proofs/lean4/FilesystemCNO.lean
@@ -5,7 +5,7 @@
 
    Author: Jonathan D. A. Jewell
    Project: Absolute Zero (integrating Valence Shell)
-   License: AGPL-3.0 / Palimpsest 0.5
+   License: PMPL-1.0-or-later
 -/
 
 -- Std.Data.List.Basic was vestigial in pre-Batteries layouts. The List

--- a/proofs/lean4/LambdaCNO.lean
+++ b/proofs/lean4/LambdaCNO.lean
@@ -7,7 +7,7 @@
 
    Author: Jonathan D. A. Jewell
    Project: Absolute Zero
-   License: AGPL-3.0 / Palimpsest 0.5
+   License: PMPL-1.0-or-later
 -/
 
 namespace LambdaCNO

--- a/proofs/lean4/QuantumCNO.lean
+++ b/proofs/lean4/QuantumCNO.lean
@@ -5,7 +5,7 @@
 
    Author: Jonathan D. A. Jewell
    Project: Absolute Zero
-   License: AGPL-3.0 / Palimpsest 0.5
+   License: PMPL-1.0-or-later
 -/
 
 import Mathlib.Data.Real.Basic

--- a/proofs/lean4/StatMech.lean
+++ b/proofs/lean4/StatMech.lean
@@ -5,7 +5,7 @@
 
    Author: Jonathan D. A. Jewell
    Project: Absolute Zero
-   License: AGPL-3.0 / Palimpsest 0.5
+   License: PMPL-1.0-or-later
 -/
 
 import CNO

--- a/src/AuditTrail.res
+++ b/src/AuditTrail.res
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: PMPL-1.0-or-later
+// Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
+
 // AuditTrail.res - DOM annotation for debugging
 // Injects data-audit paths into the DOM
 

--- a/src/brainfuck/src/main.rs
+++ b/src/brainfuck/src/main.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: PMPL-1.0-or-later
+// Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
+
 //! Brainfuck CNO Detection CLI
 //!
 //! Tests various Brainfuck programs for CNO properties.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: PMPL-1.0-or-later
+// Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
+
 //! Certified Null Operation in Rust
 //!
 //! A program that does absolutely nothing at the application level.


### PR DESCRIPTION
**Refs** hyperpolymath/standards#133 and hyperpolymath/standards#124. **NOT Closes** — the proof-debt arm (main is unsound until the rescue branch lands; `eval_deterministic`) is separate.

Draft / human-gated. Owner-ruled after an authorship check.

### Authorship verdict (read-only, pre-approved by owner)
`git shortlog -sne --all` + per-file `git log`: **every affected file is 100% owner-own** (Jonathan D.A. Jewell); dependabot touched only CI; nothing vendored/third-party; **no AGPL-by-intent**. The `AGPL-3.0 / Palimpsest 0.5` strings are scaffold-placeholder drift (the ledger root cause), not a deliberate election. Because the check returns owner-own uniformly, canonicalising to `PMPL-1.0-or-later` does **not** violate the ledger's "no flat default" guard (that guard forbids defaulting *without* a check).

### Changes (18 files)
| Group | Count | Action |
|---|---|---|
| Proof files w/ `License: AGPL-3.0 / Palimpsest 0.5` | 13 | → `License: PMPL-1.0-or-later` (matches the 2 already-correct files) |
| Missing-header files | 4 | added canonical header — `StatMech_helpers.v` in repo proof-file doc-comment form; `src/main.rs`, `src/brainfuck/src/main.rs`, `src/AuditTrail.res` with estate SPDX+Copyright |
| `LICENSE-PALIMPS.txt` (0 bytes) | 1 | **deleted** |

**Correction to the earlier audit:** `LICENSE-PALIMPS.txt` is *not* referenced by root `LICENSE` (which references `EXHIBIT-A/B`). The repo's own audit trail (`LICENSE-AUDIT-2026-02-05.adoc`, `ROADMAP-V1-TO-V12.adoc`, `SESSION-COMPLETE-2026-02-05.adoc`) already prescribes removing the 0-byte stub — so **delete** (not populate) is the owner-consistent resolution. Canonical text remains in `license/PMPL-1.0.txt` + root `LICENSE`.

Header-only; no proof semantics touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)