### PR TITLE
fix(lean4/cno): finish loadStore_preserves_memory cons-case build

### DIFF
--- a/proofs/lean4/CNO.lean
+++ b/proofs/lean4/CNO.lean
@@ -384,7 +384,7 @@ def loadStoreSame (addr : Nat) : Program :=
 
 /- ── Helper lemmas for loadStore_preserves_memory ──────────────────────────
 
-   These three private lemmas establish the round-trip property of
+   These three private theorems establish the round-trip property of
    `setReg`/`getReg` for register index 0 and the no-op character of
    `Memory.update m addr (m addr)`.  They are the rewrite-lemma layer
    mentioned in the DEFERRED comment below.
@@ -396,18 +396,18 @@ def loadStoreSame (addr : Nat) : Program :=
    `Memory.update_same_pointwise` is the key identity-update fact: writing
    the value already stored at an address is a no-op, point-wise. -/
 
-private lemma setReg_cons_zero (r val : Nat) (rs : List Nat) :
+private theorem setReg_cons_zero (r val : Nat) (rs : List Nat) :
     setReg (r :: rs) 0 val = val :: rs := by
   unfold setReg
   rfl
 
-private lemma getReg_cons_zero (val : Nat) (rs : List Nat) :
+private theorem getReg_cons_zero (val : Nat) (rs : List Nat) :
     getReg (val :: rs) 0 = some val := by
   unfold getReg
   rfl
 
 /-- Writing the value already at `addr` back to `addr` is a pointwise no-op. -/
-private lemma Memory.update_same_pointwise (m : Memory) (addr a : Nat) :
+private theorem Memory.update_same_pointwise (m : Memory) (addr a : Nat) :
     Memory.update m addr (m addr) a = m a := by
   unfold Memory.update
   -- The branch condition is `a == addr : Bool`.  We case-split on whether
@@ -475,12 +475,10 @@ theorem loadStore_preserves_memory (addr : Nat) (s : ProgramState) :
     -- ⟹ the store instruction takes the `none` error branch → leaves
     --    memory and registers unchanged.
     -- `unfold setReg getReg` expands both defs by their match clauses.
-    -- `simp only []` then applies ι-reductions: `[].get? 0 ↝ none`,
-    -- `match none with ... | none => X ↝ X`, and `.memory` projection;
-    -- the goal collapses to `Memory.eq s.memory s.memory`.
+    -- ι-reductions then collapse the goal: `[].get? 0 ↝ none`,
+    -- `match none with ... | none => X ↝ X`, and `.memory` projection
+    -- happen by definitional equality, so `rfl` closes after `intro a`.
     unfold setReg getReg
-    simp only []
-    -- Goal: Memory.eq s.memory s.memory
     intro a
     rfl
   | cons r rs =>


### PR DESCRIPTION
## Summary

Lean half of standards#133. Repair two root-cause defects that prevented `lake build` from completing on `proofs/lean4/CNO.lean`:

1. **`private lemma` keyword** used in 3 helper lemmas (`setReg_cons_zero`, `getReg_cons_zero`, `Memory.update_same_pointwise`). `lemma` is a Mathlib alias, but this file ships with **zero imports** by intentional design (L11–13 comment). Lean 4 core parser only accepts `theorem`. Switched all 3 to `private theorem`. The downstream "unknown identifier `setReg_cons_zero`" error at L498 was a cascading consequence and resolved too.
2. **Redundant `simp only []` at L482** in the nil-branch of `loadStore_preserves_memory`. Lean 4.16's `simp only` is strict about needing at least one lemma. After `unfold setReg getReg`, the goal reduces to `Memory.eq s.memory s.memory` by definitional equality alone (kernel ι-reductions on `[].get?` and the `match none with ... | none => s` arm). Dropping `simp only []` lets `intro a; rfl` close.

## Test plan

- [x] `lake build CNO` exits 0
- [x] `lake build` (full project, 6 libraries) exits 0
- [x] Only linter warnings remain (`unused variable` at L37/L181/QuantumCNO; pre-existing, not in scope)
- [x] No `sorry` or `axiom` introduced in `CNO.lean` (verified: `CNO.lean` is axiom-free; the existing axioms in `LambdaCNO.lean`/`StatMech.lean`/`FilesystemCNO.lean` are out of scope for this issue)

## Refs

\`Refs hyperpolymath/standards#133\` — Lean half of \"[P2] absolute-zero: finish Lean CNO cons-case + Coq tier-0 rebuild\". The Coq tier-0 rebuild (4 axioms in \`proofs/coq/common/CNO.v\`: \`eval_deterministic\`, \`cno_decidable\`, \`eval_respects_state_eq_{left,right}\`) is the other half and will be filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)