### PR TITLE
fix(coq/cno): drop cno_decidable axiom (Rice's theorem territory)

### DIFF
--- a/proofs/coq/common/CNO.v
+++ b/proofs/coq/common/CNO.v
@@ -572,9 +572,21 @@ Qed.
 (** ** Decidability *)
 
 (** Question: Is CNO verification decidable? *)
-(** This is a major research question *)
 
-Axiom cno_decidable : forall p, {is_CNO p} + {~ is_CNO p}.
+(** Universal decidability of [is_CNO] over arbitrary programs was
+    previously asserted as an [Axiom] [cno_decidable]. That axiom has
+    been dropped (owner ruling, Stage 3 of standards#157): the
+    universal form asks for a constructive decision procedure over an
+    unbounded state space ([Memory : nat -> nat], unbounded
+    registers, unbounded I/O traces), and [is_CNO]'s
+    universally-quantified clauses range over all of them. This is
+    essentially the Rice's-theorem situation: deciding a non-trivial
+    semantic property of an arbitrary program is undecidable, so the
+    universal-decidability claim is not constructively achievable in
+    Coq and any client that wants decidability must work in a
+    restricted syntactic fragment of [Program] (which the current
+    development does not formalise). No theorem in this file depended
+    on it. *)
 
 (** ** Complexity *)
 


### PR DESCRIPTION
Salvaged from #25 — the only commit on that branch with content **not** already on `main` in some form.

## What

Drops `Axiom cno_decidable : forall p, {is_CNO p} + {~ is_CNO p}` from `proofs/coq/common/CNO.v` (owner ruling, Stage 3 of standards#157).

Replaces the axiom line with a doc comment explaining why: universal decidability of \`is_CNO\` over arbitrary programs asks for a constructive decision procedure over an unbounded state space (\`Memory : nat -> nat\`, unbounded registers, unbounded I/O traces), and \`is_CNO\`'s universally-quantified clauses range over all of them — Rice's-theorem territory, not constructively achievable.

## Verification

- `coqc -R common CNO common/CNO.v` — builds clean locally on Coq 8.18.0.
- `grep -rn cno_decidable proofs/` — only the new doc-comment reference remains; no theorem in the corpus depended on it.

## Provenance

Cherry-pick of `8b78d27` from #25. The other commit on #25 (`89deef7`, eval_respects_state_eq via existential reformulation) is **not** salvaged here because `main` already discharges those two axioms a different way (#26 `99ec572`, deletion + downstream refactor) — the existential approach is competing, not additive.

Closes #25 once merged; #33 and #35 closed as superseded separately.

Refs standards#124, standards#157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>