### PR TITLE
fix(governance): enumerate banned-language demos in .hypatia-ignore

### DIFF
--- a/.hypatia-ignore
+++ b/.hypatia-ignore
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: MPL-2.0
+#
+# Estate-policy exemptions for the absolute-zero language-demonstration
+# repo. This repo intentionally ships example files in many banned and
+# allowed languages — it is the canonical "what NOT to use, here is what
+# you'd get" exemplar. Each entry below is a language-demo file under
+# `examples/` or a one-off interpreter implementation, not load-bearing
+# code.
+#
+# After standards#180 (file_pattern glob support in in_baseline()) merges,
+# this whole file collapses to a single `examples/**` file_pattern entry
+# in .hypatia-baseline.json. Tracked in the standards repo as a follow-up.
+
+# ReScript demonstration files (banned 2026-04-30 — kept as historical
+# examples until the .res→.affine migration ships).
+cicd_rules/banned_language_file:src/AuditTrail.res
+cicd_rules/banned_language_file:interpreters/rescript/malbolgeInterpreter.res
+cicd_rules/banned_language_file:examples/SafeDOMExample.res
+
+# Banned-language example files used to demonstrate the cross-language
+# nop-semantics study. None are imported into the toolchain build.
+cicd_rules/banned_language_file:examples/go/nop.go
+cicd_rules/banned_language_file:examples/java/Nop.java
+cicd_rules/banned_language_file:examples/java/BalancedOps.java
+cicd_rules/banned_language_file:examples/kotlin/Nop.kt
+cicd_rules/banned_language_file:examples/kotlin/BalancedOps.kt
+cicd_rules/banned_language_file:examples/swift/Nop.swift


### PR DESCRIPTION
## Summary

Adds a `.hypatia-ignore` with 9 exemptions for the cross-language demonstration files this repo ships by design (`examples/{java,kotlin,swift,go}/*` + the 3 legacy `.res` files).

## Why

absolute-zero is the estate's language-demonstration repo — it ships example files in ~9 banned languages on purpose, to illustrate "what NOT to use." Since standards#168 merged (governance-reusable.yml now covers Java/Kotlin/Swift/Dart/V-lang/ATS2/Makefile in addition to ReScript/Go/Python), every push to `main` has gone red on `governance / Language / package anti-pattern policy`.

Latest 3 runs on main: all failure (governance.yml runs 26407681719, 26371098456, 26333708931).

## Files exempted

| Language | File | Reason |
|---|---|---|
| .res | `src/AuditTrail.res` | Legacy ReScript pre-`.affine` migration |
| .res | `interpreters/rescript/malbolgeInterpreter.res` | Demo interpreter |
| .res | `examples/SafeDOMExample.res` | DOM example |
| .go | `examples/go/nop.go` | Cross-lang nop study |
| .java | `examples/java/Nop.java` | Cross-lang nop study |
| .java | `examples/java/BalancedOps.java` | Cross-lang ops study |
| .kt | `examples/kotlin/Nop.kt` | Cross-lang nop study |
| .kt | `examples/kotlin/BalancedOps.kt` | Cross-lang ops study |
| .swift | `examples/swift/Nop.swift` | Cross-lang nop study |

None are imported into the toolchain build.

## Follow-up

Once standards#180 (file_pattern glob matching in `in_baseline()`) merges, this whole enumerated list can collapse to a single `examples/**` `file_pattern` entry in `.hypatia-baseline.json`. The `.res` files will migrate to `.affine` separately under the existing 2026-Q3 plan.

## Test plan

- [ ] CI: governance/Language-policy step passes (9 exempt entries visible in run log)
- [ ] absolute-zero main goes green for the first time since standards#168

🤖 Generated with [Claude Code](https://claude.com/claude-code)