### PR TITLE
chore(spdx): migrate PMPL-1.0-or-later → MPL-2.0 (20 files)

### DIFF
--- a/AUDIT.adoc
+++ b/AUDIT.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PMPL-1.0-or-later
+// SPDX-License-Identifier: MPL-2.0
 = Absolute Zero — Audit Trail
 Jonathan D. A. Jewell <developer@joshuajewell.dev>
 :toc:

--- a/ROADMAP.adoc
+++ b/ROADMAP.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PMPL-1.0-or-later
+// SPDX-License-Identifier: MPL-2.0
 = Absolute Zero: Roadmap to v12.0
 Jonathan D. A. Jewell <jonathan.jewell@open.ac.uk>
 :toc: left

--- a/RSR_COMPLIANCE.adoc
+++ b/RSR_COMPLIANCE.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PMPL-1.0-or-later
+// SPDX-License-Identifier: MPL-2.0
 = Absolute Zero — Rhodium Standard Repository (RSR) Compliance
 Jonathan D. A. Jewell <developer@joshuajewell.dev>
 :toc:

--- a/docs/archive/ROADMAP-2026-02-05.adoc
+++ b/docs/archive/ROADMAP-2026-02-05.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PMPL-1.0-or-later
+// SPDX-License-Identifier: MPL-2.0
 = Absolute Zero Roadmap
 Jonathan D. A. Jewell <jonathan.jewell@open.ac.uk>
 :toc:

--- a/docs/archive/SESSION-2026-05-25-HANDOFF.adoc
+++ b/docs/archive/SESSION-2026-05-25-HANDOFF.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PMPL-1.0-or-later
+// SPDX-License-Identifier: MPL-2.0
 = Session Handoff — 2026-05-25 Repo Tidy
 Claude (session 7927557c-2938-4d53-b987-a6f8ebc44611)
 :toc:

--- a/docs/wiki/ABI.md
+++ b/docs/wiki/ABI.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: PMPL-1.0-or-later -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
 # ABI
 
 The Idris2 ABI surface at `src/abi/` declares the FFI boundary that the

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: PMPL-1.0-or-later -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
 # Architecture
 
 Three layers, loosely coupled.

--- a/docs/wiki/Audit-Trail.md
+++ b/docs/wiki/Audit-Trail.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: PMPL-1.0-or-later -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
 # Audit Trail
 
 Short summary; the authoritative ledger is [`AUDIT.adoc`](../../AUDIT.adoc).

--- a/docs/wiki/Contributing.md
+++ b/docs/wiki/Contributing.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: PMPL-1.0-or-later -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
 # Contributing
 
 Short summary; the authoritative version is [`CONTRIBUTING.adoc`](../../CONTRIBUTING.adoc) at the root.

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: PMPL-1.0-or-later -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
 # FAQ
 
 ### Why prove that a program does nothing?

--- a/docs/wiki/Glossary.md
+++ b/docs/wiki/Glossary.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: PMPL-1.0-or-later -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
 # Glossary
 
 | Term | Definition |

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: PMPL-1.0-or-later -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
 # Absolute Zero — Wiki
 
 > **Formal Verification of Certified Null Operations: When Doing Nothing Is Everything.**

--- a/docs/wiki/Proof-Systems.md
+++ b/docs/wiki/Proof-Systems.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: PMPL-1.0-or-later -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
 # Proof Systems
 
 ## Why six?

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: PMPL-1.0-or-later -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
 # docs/wiki — In-repo source for the GitHub Wiki
 
 These markdown pages are the canonical source for

--- a/docs/wiki/Roadmap.md
+++ b/docs/wiki/Roadmap.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: PMPL-1.0-or-later -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
 # Roadmap
 
 Short summary; the authoritative version is [`ROADMAP.adoc`](../../ROADMAP.adoc) at the root.

--- a/docs/wiki/Verification.md
+++ b/docs/wiki/Verification.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: PMPL-1.0-or-later -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
 # Verification
 
 How to verify locally and what CI does.

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: PMPL-1.0-or-later -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
 **[Home](Home)**
 
 **Project**

--- a/tests/README.adoc
+++ b/tests/README.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PMPL-1.0-or-later
+// SPDX-License-Identifier: MPL-2.0
 = tests/ — Test suite root
 
 This directory is the conventional RSR location for tests. For

--- a/tools/README.adoc
+++ b/tools/README.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PMPL-1.0-or-later
+// SPDX-License-Identifier: MPL-2.0
 = tools/ — Developer tools
 
 RSR-conventional location for developer utilities (scripts that build,

--- a/verification/README.adoc
+++ b/verification/README.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PMPL-1.0-or-later
+// SPDX-License-Identifier: MPL-2.0
 = verification/ — Formal verification entry points
 
 RSR-conventional location for verification scripts. These wrap the


### PR DESCRIPTION
## Summary

The repo's LICENSE file is canonical **MPL-2.0** (migrated in absolute-zero#42 alongside the wrapper-conversion sweep). But 20 files across the repo still carried the legacy `PMPL-1.0-or-later` SPDX header.

Per estate language policy ([`feedback_estate_lang_policy_2026_05_25`](../../README.md#license)): `PMPL-1.0/MPL-1.0 → MPL-2.0`. This PR brings the headers in line with the LICENSE.

## Files touched (all mechanical)

- 3 root .adoc: `AUDIT.adoc`, `ROADMAP.adoc`, `RSR_COMPLIANCE.adoc`
- 12 `docs/wiki/*.md`
- 3 `*/README.adoc` (tests, tools, verification)
- 2 `docs/archive/*.adoc`

## Verification

Post-merge `grep -rl 'PMPL-1.0-or-later'` returns 0 hits outside of git history.