### PR TITLE
chore(ci): bump standards reusable pins past #219 governance fix

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -31,4 +31,4 @@ permissions:
 
 jobs:
   governance:
-    uses: hyperpolymath/standards/.github/workflows/governance-reusable.yml@3ec2e85cc1d54ec2ab20a84fcba96e5008545925 # main 2026-05-25
+    uses: hyperpolymath/standards/.github/workflows/governance-reusable.yml@5eb28d7d8790d5389b7b6a5233fe6265a775e3d0 # main 2026-05-27 (post-#219 workflow_sha fix)

--- a/.github/workflows/hypatia-scan.yml
+++ b/.github/workflows/hypatia-scan.yml
@@ -25,5 +25,5 @@ permissions:
 
 jobs:
   hypatia:
-    uses: hyperpolymath/standards/.github/workflows/hypatia-scan-reusable.yml@97df762107501909f50bb770e9bc200b6c415600
+    uses: hyperpolymath/standards/.github/workflows/hypatia-scan-reusable.yml@5eb28d7d8790d5389b7b6a5233fe6265a775e3d0
     secrets: inherit


### PR DESCRIPTION
## Root cause

`.github/workflows/governance.yml:34` pins `governance-reusable.yml@3ec2e85` (2026-05-25) — predates [standards#219](https://github.com/hyperpolymath/standards/pull/219) (`ad366b6`, 2026-05-27) which fixes `workflow_sha` resolution. Without this fix, `governance / Language / package anti-pattern policy` fails with exit 128 on the inner self-checkout.

## Pins changed

| File | Before | After |
|---|---|---|
| `.github/workflows/governance.yml:34` | `3ec2e85` (pre-#219) | `5eb28d7` (standards/main, post-#219) |
| `.github/workflows/hypatia-scan.yml:28` | `97df762` (orphan PR-branch SHA) | `5eb28d7` (canonical main; file unchanged since #193) |

## Auto-merge

SQUASH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)