### PR TITLE
ci(scorecard): add job-level permissions for reusable workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,5 +12,8 @@ permissions: read-all
 
 jobs:
   analysis:
+    permissions:
+      security-events: write
+      id-token: write
     uses: hyperpolymath/standards/.github/workflows/scorecard-reusable.yml@e0caf11508a3989574713c78f5f444f2ce5e33ef
     secrets: inherit


### PR DESCRIPTION
## Summary

Adds the job-level `permissions: { security-events: write, id-token: write }` block to the `analysis` job in `.github/workflows/scorecard.yml`, fixing the silent `startup_failure` on every Scorecard run.

## Why

`scorecard-reusable.yml`'s docstring states:

> Caller MUST grant `security-events: write` and `id-token: write` on the calling job. The reusable re-asserts these on its own analysis job, but **called-workflow permissions are CAPPED by the caller's permissions block.**

The wrapper currently only sets `permissions: read-all` at the workflow level, with no job-level override. Result: ossf/scorecard-action cannot upload SARIF, the workflow fails at startup, and you see no logs because the failure happens before any job runs.

## Same pattern

Fixed in `julia-professional-registry#19` 2026-05-27. Estate-wide sweep tracked separately (37 wrappers affected; see standards-side tracking).

## Test plan

- [ ] Next Scorecard run completes successfully (cron `'23 4 * * 1'` — Monday 04:23)
- [ ] SARIF appears in Security tab
- [ ] No startup_failure runs after merge

Refs hyperpolymath/standards (estate scorecard convention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)