### PR TITLE
docs(ond): add Observational Null Operations as a co-equal second pillar (design + roadmap)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 // Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 # Absolute Zero
 
-**Formal Verification of Certified Null Operations: When Doing Nothing Is Everything**
+**Formal Verification of Null Operations — two co-equal pillars: Certified Null _Effect_ (CNO) and Certified Null _Disclosure_ (OND)**
 
 image:https://img.shields.io/badge/License-MPL_2.0-blue.svg[MPL-2.0]
 image:https://img.shields.io/badge/Sponsor-%E2%9D%A4-pink?logo=github[Sponsor,link="https://github.com/sponsors/hyperpolymath"]
@@ -29,6 +29,17 @@ This seemingly trivial question leads to deep insights in:
 - **Reversible Computing**: Programs preserving thermodynamic reversibility
 - **Esoteric Languages**: Using Malbolge as proof-of-concept
 
+## The Two Pillars
+
+Absolute Zero rests on **two co-equal pillars** — siblings of equal weight, not parent and extension:
+
+- **CNO — Certified Null _Effect_.** Certifies that an operation does *nothing to the world*: it terminates, maps input state to identical output state, is functionally pure, and is thermodynamically reversible (Landauer/Bennett). The conserved quantity is **state**.
+- **OND — Observational Null Operations / Certified Null _Disclosure_.** Certifies that an operation *reveals nothing about its secret input* to a declared observer: its observable trace (timing, size, …) is constant over the secret, **relative to a declared observation model `O`**. The conserved quantity is the **secret→observable channel**.
+
+The two are **logically independent** (neither entails the other — a proved theorem, with witnesses), connected by a single *coupling dial* between a thing and the trace it casts to an observer: CNO witnesses the emptiness of the **effect** channel; OND certifies the emptiness of the **disclosure** channel (this dial is *framing, not theorem*). Unlike CNO — which lives entirely inside the formal model — every OND claim is **conditional on its declared `O`** and ships a **residue list** of out-of-scope observables: the honest, explicit boundary between the proof and the physical metal.
+
+See **`docs/TWO-PILLARS.adoc`** (narrative), **`docs/OND-ROADMAP.adoc`** (prioritised obligations), and **`docs/OND-PILLAR-STRUCTURE.adoc`** (module layout). The OND pillar is at the design/roadmap stage: its obligations are currently `Admitted` (specified, not yet proved) — the normal honest starting state, mirroring CNO's own open obligations.
+
 ## Project Structure
 
 ```
@@ -54,7 +65,10 @@ absolute-zero/
 │   ├── z3/                  # Z3 SMT verification (automated)
 │   ├── agda/                # Agda proofs (dependent types)
 │   ├── isabelle/            # Isabelle/HOL (production-grade)
-│   └── mizar/               # Mizar proofs (mathematical library)
+│   ├── mizar/               # Mizar proofs (mathematical library)
+│   ├── observation-models/  # OND: declared observation models O (proof inputs)
+│   └── residue/             # OND: residue lists (the model-vs-metal gap)
+│   # Each prover dir hosts CNO.* and (to author) co-equal OND.* modules
 │
 ├── interpreters/            # Language interpreters with CNO detection
 │   ├── rescript/            # Malbolge (ReScript)

--- a/ROADMAP.adoc
+++ b/ROADMAP.adoc
@@ -17,6 +17,51 @@ This roadmap charts Absolute Zero's evolution from a research prototype (current
 
 ---
 
+== The Second Pillar: Observational Null Operations (OND)
+
+Absolute Zero is now a **two-pillar** project. Alongside **CNO** (Certified
+Null _Effect_ — "does nothing to the world"), the **OND** pillar (Certified
+Null _Disclosure_ — "reveals nothing about its secret input, relative to a
+declared observation model `O`") is added as a **co-equal sibling**, not an
+extension. The two are logically independent (a proved theorem, with
+witnesses) and connected by a *coupling-dial* frame (framing, not theorem).
+The honest edge of OND is the **model-vs-metal boundary**: every OND claim is
+*conditional* on its declared `O` and ships a **residue list** of out-of-scope
+observables.
+
+**OND obligations** (prioritised; full detail in `docs/OND-ROADMAP.adoc`):
+
+1. *OND-1* — the OND definition, formalised (parameterised by `O`, emitting a
+   residue list). **Keystone.**
+2. *OND-2* — trivial-case satisfiability (skip is OND in any `O`) — the
+   definition's smoke-test.
+3. *OND-3* — the CNO ⊥ OND **independence theorem** (the result that earns the
+   two-pillar split).
+4. *OND-4* — a conditional-proof **template** for one real constant-time
+   operation (+ its metal-discharge statement and residue list).
+5. *OND-5* — the **non-composition** counterexample (ONDs do *not* compose
+   cleanly — state-chaining + emergent boundary observables; the DP-budget /
+   quasi-identifier shape).
+6. *OND-6* — the **conditional composition** theorem (the heavily-qualified
+   positive result; research-grade; last).
+7. *OND-7* — the ongoing **residue register** (the standing proof↔reality gap).
+
+**Status**: design/roadmap stage. All OND obligations are currently `Admitted`
+(specified, not yet proved) — the normal honest starting state, mirroring
+CNO's own open obligations (see `docs/PROOF-CLASSIFICATION.adoc`). Authoring
+the OND proofs is deferred; this roadmap and `docs/OND-ROADMAP.adoc` /
+`docs/TWO-PILLARS.adoc` / `docs/OND-PILLAR-STRUCTURE.adoc` specify the work.
+
+[NOTE]
+====
+The proof effort must investigate OND-5/OND-6 (composition) most carefully: if
+it concludes ONDs compose as cleanly as CNOs, that conclusion is almost
+certainly wrong (it has dropped either the state-chaining or the
+boundary-observable term) and must be re-checked.
+====
+
+---
+
 == Current State (v1.0.0-alpha, 50%)
 
 === Completed ✅

--- a/docs/OND-PILLAR-STRUCTURE.adoc
+++ b/docs/OND-PILLAR-STRUCTURE.adoc
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+= OND Pillar Structure: Directory and Module Layout
+:toc:
+:sectnums:
+
+[abstract]
+This document specifies the directory and module layout for the *Observational
+Null Operations (OND)* pillar. It mirrors the existing CNO multi-prover layout
+as closely as the conceptual differences allow, and adds the two OND-specific
+artifacts CNO does not need: *declared observation models* and *residue lists*.
+*No proof files are created by this design* — the per-prover OND modules below
+are specified for a dedicated proof effort to author (see `OND-ROADMAP.adoc`).
+The OND-specific *artifact* directories and their templates *are* created, since
+they are documentation inputs/outputs, not proofs.
+
+== Co-equality principle
+
+OND modules are *siblings* of the CNO modules, not children. Wherever CNO has
+`CNO.<ext>` in a prover directory, OND has `OND.<ext>` *alongside* it in the
+same directory — same prover, same build, same composition-theorem discipline,
+same decidable-for-bounded-programs caveat. Neither pillar is nested under the
+other. The only structural *addition* for OND is the pair of artifact trees
+(`proofs/observation-models/`, `proofs/residue/`), because an OND claim has two
+extra parts — a declared `O` (input) and a residue list (output) — that have no
+CNO analogue.
+
+== Per-prover module layout (mirrors CNO — TO BE AUTHORED)
+
+Each OND module sits beside its CNO counterpart. These files are *specified
+here, to be created by the proof effort* — they are not created by this design.
+
+[cols="1,2,2,3",options="header"]
+|===
+| Prover | CNO (exists) | OND (to author) | Obligations (see OND-ROADMAP)
+
+| *Coq*
+| `proofs/coq/common/CNO.v`
+| `proofs/coq/observational/OND.v`
+| OND-1 definition
+| *Coq*
+| `proofs/coq/category/CNOCategory.v`
+| `proofs/coq/observational/ONDIndependence.v`
+| OND-3 independence (needs `is_CNO` + `is_OND`)
+| *Coq*
+| `proofs/coq/lambda/LambdaCNO.v`
+| `proofs/coq/observational/ONDComposition.v`
+| OND-5 non-composition, OND-6 conditional composition
+
+| *Lean 4*
+| `proofs/lean4/CNO.lean`
+| `proofs/lean4/OND.lean`
+| OND-1, OND-2
+| *Lean 4*
+| `proofs/lean4/CNOCategory.lean`
+| `proofs/lean4/ONDIndependence.lean`
+| OND-3
+| *Lean 4*
+| `proofs/lean4/LambdaCNO.lean`
+| `proofs/lean4/ONDComposition.lean`
+| OND-5, OND-6
+
+| *Agda*
+| `proofs/agda/CNO.agda`
+| `proofs/agda/OND.agda`
+| OND-1 (dependent-typed presentation)
+
+| *Z3*
+| `proofs/z3/verify.sh`
+| `proofs/z3/ond_verify.sh`
+| OND-2, OND-3, OND-4, OND-5 (bounded/finite instances)
+
+| *Isabelle/HOL*
+| `proofs/isabelle/CNO.thy`
+| `proofs/isabelle/OND.thy`
+| OND-6 (heavier metatheory)
+
+| *Mizar*
+| `proofs/mizar/CNO.miz`
+| `proofs/mizar/OND.miz`
+| OND-1, OND-3 (mathematical-library presentation)
+|===
+
+[NOTE]
+====
+The Coq tree introduces one new subdirectory, `proofs/coq/observational/`,
+parallel to the existing `common/`, `category/`, `lambda/`, `physics/`,
+`quantum/`, `filesystem/`, `malbolge/`. This keeps the OND Coq modules grouped
+without nesting them under CNO. Lean 4, Agda, Isabelle, and Mizar keep their
+flat per-file layout, so OND files sit directly beside the CNO files.
+====
+
+== OND-specific artifact trees (CREATED by this design)
+
+These two directories *are* created now, with `README.adoc` and a `TEMPLATE`,
+because they hold documentation artifacts (proof inputs/outputs), not proofs.
+
+[source]
+----
+proofs/
+├── observation-models/        # declared observation models O (proof INPUTS)
+│   ├── README.adoc            # what an observation model is + how to declare one
+│   └── TEMPLATE.adoc         # copy-per-claim skeleton for a declared O
+└── residue/                   # residue lists (proof OUTPUTS / the metal gap)
+    ├── README.adoc            # what a residue list is + the discipline
+    └── TEMPLATE.adoc         # copy-per-claim skeleton for a residue list
+----
+
+* *`proofs/observation-models/`* — one declared `O` per OND claim (or per
+  platform/operation family). A declared `O` is the *required input* to every
+  OND proof: the explicit, enumerated list of what the observer is assumed to
+  see (e.g. wall-clock time, output length, allocation-size sequence, branch
+  pattern). The proof's *consequent* ("constant over the secret") is proved
+  relative to this `O`.
+
+* *`proofs/residue/`* — one residue list per OND claim: the observables
+  *deliberately out of scope* of that claim's `O` (e.g. power analysis,
+  speculative-execution channels, DRAM row-buffer timing, EM emanation). The
+  residue list is the *formal specification of the gap between the proof and
+  physical reality* — the standing record (OND-7) an engineer reads to learn
+  which channels they still own.
+
+== Where each roadmap obligation lives
+
+[cols="1,3",options="header"]
+|===
+| Obligation | Home
+
+| OND-1 definition | `proofs/{coq/observational,lean4,agda,mizar}/OND*` + the
+  `O` parameterisation pattern documented in `observation-models/README.adoc`
+| OND-2 trivial case | `proofs/lean4/OND.lean`, `proofs/coq/observational/OND.v`,
+  `proofs/z3/ond_verify.sh`
+| OND-3 independence | `proofs/{coq/observational,lean4}/ONDIndependence.*`,
+  witnesses checked in `proofs/z3/ond_verify.sh`
+| OND-4 conditional template | `proofs/{coq/observational,lean4}/OND*` for the
+  conditional, with a declared `O` in `observation-models/` and a residue list
+  in `residue/`
+| OND-5 non-composition | `proofs/{coq/observational,lean4}/ONDComposition.*`,
+  joint-observable check in `proofs/z3/ond_verify.sh`
+| OND-6 conditional composition | `proofs/{coq/observational,lean4}/ONDComposition.*`,
+  `proofs/isabelle/OND.thy`
+| OND-7 residue register | `proofs/residue/` (ongoing)
+|===
+
+== Documentation and governance touch-points
+
+* `docs/TWO-PILLARS.adoc` — the narrative spine (CNO + OND co-equal).
+* `docs/OND-ROADMAP.adoc` — the prioritised obligations.
+* `docs/PROOF-CLASSIFICATION.adoc` — the CNO honesty template OND mirrors; when
+  OND proofs begin, add an OND section (or a sibling `OND-CLASSIFICATION.adoc`)
+  using the same per-obligation format.
+* `README.adoc` — presents the two pillars co-equally (see its "Two Pillars"
+  section).
+* `proofs/<prover>/README.adoc` — when OND modules land, list them beside the
+  CNO modules so the co-equality is visible in each prover directory.
+
+== Build and CI
+
+OND modules join the *same* build as CNO in each prover (no separate
+toolchain): the Lean `lakefile`/`lake-manifest`, the Coq `_CoqProject`, the
+Agda/Isabelle/Mizar invocations, and `proofs/z3/ond_verify.sh` beside
+`verify.sh`. When the OND modules are authored, register them in the existing
+per-prover build manifests so `just`/CI cover both pillars identically.
+
+[IMPORTANT]
+====
+This document creates *only* the two artifact trees (`observation-models/`,
+`residue/`) with their READMEs and templates. The per-prover `OND*` proof
+modules above are *specified, not created* — authoring them is the proof effort
+described in `OND-ROADMAP.adoc`, explicitly deferred.
+====

--- a/docs/OND-ROADMAP.adoc
+++ b/docs/OND-ROADMAP.adoc
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+= OND Roadmap: Bringing the Disclosure Pillar to Parity with CNO
+:toc:
+:sectnums:
+
+[abstract]
+This is the prioritised proof roadmap for *Observational Null Operations
+(OND)*, the second pillar of Absolute Zero (see `TWO-PILLARS.adoc`). It mirrors
+the per-obligation format of `PROOF-CLASSIFICATION.adoc`. Every obligation
+states what it claims, which proof system(s) suit it, its honesty *label*
+(framing / conditional / metal-discharged / proof-target), and its priority.
+*No proofs are started here* — this is the specification of the work; the
+proofs themselves are deferred to a dedicated effort.
+
+== Classification principle
+
+*Priority*: establish the OND *definition* and its *honest boundary* first,
+prove *satisfiability* and *independence from CNO* early (these justify the
+pillar's existence), and treat *composition* as the hard, surprising core —
+split into a cheap negative result and a hard conditional positive.
+
+*Honesty labels* (per `TWO-PILLARS.adoc` §"Status honesty"):
+
+* *proof-target* — a consequent dischargeable inside a proof assistant,
+  relative to a declared `O`.
+* *framing* — organising narrative; proves nothing.
+* *conditional* — proved relative to a declared `O`; carries a residue list.
+* *metal-discharged* — owed to constant-time engineering / compilation /
+  hardware measurement, *not* to the proof assistant.
+
+*Decidability caveat (inherited from CNO).* As with CNO, observational nullity
+is *decidable for bounded programs under a finite observation model `O`*
+(enumerate the secret domain, compare traces) and *undecidable in general*.
+Z3 is the right tool for the bounded/finite instances; Coq/Lean/Isabelle/Agda
+carry the general, parameterised statements.
+
+== Critique of the proposed ordering
+
+The owner's proposed order was: *(i)* OND definition; *(ii)* CNO/OND
+independence; *(iii)* OND composition; *(iv)* trivial-case proofs; *(v)*
+conditional-proof template; *(vi)* metal-discharge statement. Three changes,
+all defended below:
+
+1. *Move the trivial case up, from (iv) to #2.* "The empty operation is OND in
+   any `O`" is the *satisfiability smoke-test* for the definition: a definition
+   that nothing satisfies is malformed. It is the cheapest possible de-risk and
+   must come *before* independence and composition, right after the definition.
+
+2. *Fold the structural half of (vi) into the definition (#1); split the rest.*
+   The declared observation model (an input) and the residue list (an output)
+   are *part of an honest OND definition*, not a final step — you cannot state
+   `is_OND` honestly without `O` as a parameter and a residue obligation. So
+   (vi) is not "last". Its *structural* half belongs in #1; its *per-claim*
+   half rides with the conditional template (#4); its *ongoing* half is a
+   living register (#7).
+
+3. *Split composition (iii) into a cheap negative (#5) and a hard conditional
+   positive (#6), and do the template (v) before both.* Composition is the
+   place this most likely surprises us (see <<composition>>). The *negative*
+   result — a counterexample where two ONDs compose to a leak — is cheap,
+   honest, and high-value, so it comes early. The *positive* result is
+   research-grade and comes last. The conditional template (#4) is moved ahead
+   of composition because it exercises the whole `O`+residue machinery on one
+   real operation, which you want validated before generalising.
+
+Net order: *definition(+O+residue) → trivial case → independence →
+conditional template(+per-claim metal) → non-composition counterexample →
+conditional composition theorem → ongoing residue register.*
+
+== 🎯 OND-1 — The OND definition, formalised ⭐⭐⭐
+
+*Label*: proof-target (the definition itself) + framing scaffolding for `O`.
+
+*Statement (shape)*:
+[source]
+----
+ObservationModel : Type                       -- a trace the observer can see
+O : Execution -> ObservationModel
+is_OND (O : Execution -> Obs) (p : Program) : Prop :=
+  forall (s1 s2 : Secret) (pub : Public),
+    O (run p (s1, pub)) = O (run p (s2, pub))
+----
+
+*What it claims*: defines observational nullity *parameterised by an
+observation model `O`*, with the secret/public split explicit, and requires
+every instance to carry (a) a declared `O` and (b) a residue list.
+
+*Provers*: *Coq* and *Lean 4* first (where `is_CNO` already lives, so
+independence and composition can be stated in the same context); *Agda* for the
+dependent-typed presentation. The residue list and `O` declarations live as
+artifacts (see `OND-PILLAR-STRUCTURE.adoc`), not as prover code.
+
+*Difficulty*: 🟡 Medium — the definition is short, but getting the secret/public
+split and the `O` parameterisation right (so independence and composition are
+even *statable*) is the load-bearing design decision.
+
+*Priority*: ⭐⭐⭐ HIGHEST. Everything else depends on it.
+
+*Dependencies*: none. *This is the keystone.*
+
+== 🎯 OND-2 — Trivial-case satisfiability ⭐⭐⭐
+
+*Label*: proof-target (conditional on the trivial `O`).
+
+*Statement*: the empty/skip operation is OND under *any* observation model:
+`forall O, is_OND O skip`. (Its trace is independent of the secret because it
+does not depend on the secret at all.)
+
+*What it claims*: the definition is *non-vacuous* — at least one operation
+satisfies it, in every model. This is the smoke-test that `is_OND` is
+well-formed.
+
+*Provers*: *Coq*/*Lean 4* (trivial once OND-1 lands); *Z3* to confirm the
+finite instance automatically.
+
+*Difficulty*: 🟢 Easy.
+
+*Priority*: ⭐⭐⭐ HIGHEST — cheapest possible validation of OND-1; do it
+*immediately* after the definition.
+
+*Dependencies*: OND-1.
+
+== 🔥 OND-3 — CNO ⊥ OND independence theorem ⭐⭐⭐
+
+*Label*: proof-target (two existence witnesses + two refutations).
+
+*Statement*: `is_CNO` and `is_OND O` are logically independent —
+`(exists p, is_CNO p /\ ~ is_OND O p) /\ (exists q, is_OND O q /\ ~ is_CNO q)`.
+
+*What it claims*: neither pillar entails the other; this is what earns the
+two-pillar split. Witnesses (see `TWO-PILLARS.adoc` §Independence):
+
+* *CNO ∧ ¬OND*: a constant-result early-exit comparison — unchanged state
+  (CNO), but data-dependent timing in `O` (¬OND).
+* *OND ∧ ¬CNO*: a constant-time fixed-value write — constant trace (OND), but
+  changed state (¬CNO).
+
+*Provers*: *Coq*/*Lean 4* (needs both `is_CNO` and `is_OND` in scope). *Z3*
+discharges the two concrete witnesses against a finite timing/state model
+automatically — a good "decidable for bounded programs" demonstration.
+
+*Difficulty*: 🟡 Medium — the witnesses are simple, but `O` must include timing
+for the first witness to refute OND, which forces an early, honest choice of
+observation model.
+
+*Priority*: ⭐⭐⭐ HIGHEST — the headline theorem distinguishing the pillars.
+
+*Dependencies*: OND-1, and the existing `is_CNO`.
+
+== 📐 OND-4 — Conditional-proof template for one real operation ⭐⭐
+
+*Label*: conditional (+ a per-claim *metal-discharged* statement).
+
+*Statement*: for one concrete constant-time operation (e.g. constant-time
+select / fixed-value write), prove `is_OND O p` for an explicitly declared `O`,
+and emit its residue list.
+
+*What it claims*: the full `O`+residue machinery works end-to-end on a real,
+metal-facing operation — the reusable template every later OND claim follows.
+The *conditional* (consequent) is proved; the *antecedent* ("the metal really
+exposes only `O`") is written down explicitly as the operation's
+*metal-discharged* obligation and its residue list, *not* proved here.
+
+*Provers*: *Coq*/*Lean 4* for the conditional; *Z3* for the bounded
+constant-trace check; the declared `O` and residue list as artifacts.
+
+*Difficulty*: 🟡 Medium.
+
+*Priority*: ⭐⭐ HIGH — validates the framework before generalisation, and is
+the pattern all real OND claims reuse.
+
+*Dependencies*: OND-1, OND-2.
+
+[[composition]]
+== 🔬 OND-5 — Non-composition counterexample ⭐⭐
+
+*Label*: proof-target (a *negative* result — first-class).
+
+*Statement*: there exist operations `p`, `q` and models `O_p`, `O_q` with
+`is_OND O_p p` and `is_OND O_q q`, yet the sequential composite `p ; q` is
+*not* OND under the naive combined model `O_p ∪ O_q` —
+`~ is_OND (O_p `union` O_q) (p ; q)`.
+
+*Why this is the crux (investigated, not assumed).* CNOs compose cleanly:
+`id ∘ id = id`, trivially closed. ONDs do *not*, for two independent reasons:
+
+1. *State-chaining.* An OND *may change state* (it is not a CNO). So `q` runs
+   on `p`'s secret-dependent *output*. "`q`'s trace is constant over `q`'s
+   input secret" does *not* imply "constant over the *original* secret", once
+   `p` has folded the secret into what `q` sees as public. The leak is created
+   by the hand-off, not by either operation alone.
+
+2. *Emergent / boundary observables.* The composite's true observation model is
+   *not* `O_p ∪ O_q`. Composition creates observables present in *neither*
+   part: the relative ordering and inter-operation timing, the memory
+   high-water-mark across the boundary, cross-operation cache residency. Each
+   part can be null with respect to its own model while the *pair* leaks
+   through an observable nobody declared.
+
+This is the same shape as *differential privacy's sequential composition*
+(privacy budgets *accumulate* under composition — they do not stay flat) and
+the *"max-composition is unsound for quasi-identifiers"* worry from the
+echo/residue work: two views each individually non-disclosing can jointly
+disclose. *If a future effort reports that ONDs compose as cleanly as CNOs,
+that is the claim to check hardest* — it almost certainly dropped either the
+state-chaining or the boundary-observable term.
+
+*Provers*: *Coq*/*Lean 4* to exhibit the witnesses; *Z3* to confirm the joint
+observable distinguishes the secrets on a bounded instance.
+
+*Difficulty*: 🟡 Medium — constructing one honest counterexample is far easier
+than the general positive theorem, which is exactly why it comes first.
+
+*Priority*: ⭐⭐ HIGH — the honest, load-bearing surprise of the pillar.
+
+*Dependencies*: OND-1, OND-4 (the template surfaces the boundary observables).
+
+== 🔬 OND-6 — Conditional composition theorem ⭐
+
+*Label*: conditional (a *positive* result, heavily qualified).
+
+*Statement (shape)*: `p ; q` is OND under a combined model `O_{pq}` *iff*
+`O_{pq}` subsumes `O_p ∪ O_q` *plus* the boundary/interaction observables,
+*and* each operation is null with respect to its slice of `O_{pq}` *given the
+other's public outputs*. Naive union-composition is explicitly unsound (that is
+OND-5).
+
+*What it claims*: the precise side-conditions under which observational nullity
+*is* preserved by composition — the constructive analogue of DP's
+composition-with-budget theorems.
+
+*Provers*: *Coq*/*Lean 4*, with *Isabelle/HOL* a good fit for the heavier
+metatheory (it carries the production-grade CNO entropy work already).
+
+*Difficulty*: 🔴 HARD — research-grade; the correct statement of `O_{pq}` and
+the "given the other's public outputs" condition is itself a contribution.
+
+*Priority*: ⭐ MEDIUM — the capstone; do *last*. A pillar with OND-1..5 landed
+and OND-6 openly `Admitted` is in honest, publishable shape.
+
+*Dependencies*: OND-1..5.
+
+== 📋 OND-7 — Ongoing residue register ⭐
+
+*Label*: metal-discharged (a living artifact, not a prover obligation).
+
+*Statement*: maintain, per OND claim, the declared `O` and the enumerated
+residue list, as the running specification of the proof↔reality gap.
+
+*What it claims*: nothing new — it is the *discipline* that keeps every OND
+claim honest. The register is the single place an engineer reads to learn which
+channels the proofs do *not* cover (power, EM, speculative execution, DRAM
+row-buffer timing, …).
+
+*Provers*: none. Artifacts under `proofs/observation-models/` and
+`proofs/residue/` (see `OND-PILLAR-STRUCTURE.adoc`).
+
+*Difficulty*: 🟢 Easy (ongoing).
+
+*Priority*: ⭐ continuous from OND-4 onward.
+
+*Dependencies*: OND-4.
+
+== 📊 Summary by priority
+
+[cols="1,4,1,2,1",options="header"]
+|===
+| # | Obligation | Label | Provers | Difficulty
+
+| OND-1 | OND definition (+ `O` + residue) | proof-target / framing | Coq, Lean 4, Agda | 🟡
+| OND-2 | Trivial-case satisfiability | proof-target | Coq, Lean 4, Z3 | 🟢
+| OND-3 | CNO ⊥ OND independence | proof-target | Coq, Lean 4, Z3 | 🟡
+| OND-4 | Conditional template (one real op) | conditional + metal | Coq, Lean 4, Z3 | 🟡
+| OND-5 | Non-composition counterexample | proof-target (negative) | Coq, Lean 4, Z3 | 🟡
+| OND-6 | Conditional composition theorem | conditional | Coq, Lean 4, Isabelle | 🔴
+| OND-7 | Ongoing residue register | metal-discharged | (artifacts) | 🟢
+|===
+
+== Parity scorecard (OND vs CNO)
+
+To reach *parity with CNO*, the OND pillar wants, per the CNO precedent: a core
+definition in ≥2 provers, an identity/trivial case, a composition story
+(here: negative + conditional positive), at least one worked real-operation
+proof, and an honest open-obligations ledger. OND-1..4 give the credible core;
+OND-5 gives the honest composition surprise; OND-6 is the research capstone;
+OND-7 is the standing discipline. Until the proofs land, *every* OND obligation
+is `Admitted` — which, given how many CNO obligations are themselves openly
+`Admitted` (see `PROOF-CLASSIFICATION.adoc`), is the normal, honest starting
+state, not a regression.
+
+== Explicitly out of scope of this roadmap
+
+* *Writing any proof.* This document specifies the work; it does not start it.
+* *Discharging any antecedent.* Establishing that real hardware exposes only a
+  declared `O` is constant-time engineering / measurement (OND-7), never a
+  proof-assistant obligation.
+* *Using the coupling dial as a warrant.* The dial (see `TWO-PILLARS.adoc`) is
+  framing; no obligation above is justified by it.

--- a/docs/TWO-PILLARS.adoc
+++ b/docs/TWO-PILLARS.adoc
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+= Two Pillars of Absolute Zero: Null Effect and Null Disclosure
+:toc:
+:sectnums:
+
+[abstract]
+Absolute Zero rests on *two co-equal pillars*. The first, *Certified Null
+Operations (CNO)*, certifies that an operation does *nothing to the world*:
+it terminates, maps input state to identical output state, is functionally
+pure, and is thermodynamically reversible. The second, *Observational Null
+Operations (OND)*, certifies that an operation *reveals nothing about its
+secret input* to a declared observer: its observable trace is constant over
+the secret. The two are *siblings of equal weight*, not parent and extension.
+This document is the narrative spine that connects them without conflating
+them. It is prose, not proof; the obligations it points at live in
+`OND-ROADMAP.adoc`, and the module layout in `OND-PILLAR-STRUCTURE.adoc`.
+
+== The two pillars at a glance
+
+[cols="1,3,3",options="header"]
+|===
+| | *CNO — certified null effect* | *OND — certified null disclosure*
+
+| Conserves
+| *State.* "This operation does nothing to the world."
+| *The secret→observable channel.* "This operation reveals nothing about its
+  secret input, relative to a declared observation model `O`."
+
+| Core predicate
+| `is_CNO p` — `p` terminates, `eval p s = s`, no side effects, reversible.
+| `is_OND O p` — for every pair of secrets `s1, s2` (with the same public
+  inputs), the observable trace `O(run p s1) = O(run p s2)`.
+
+| Lives entirely in the model?
+| *Yes.* State is in the formal model, so state-equality is proved outright.
+| *No.* Real observables (timing, EM, power, cache, network residue) live at
+  a layer the formalism does not natively reach. Every OND claim is
+  *conditional* on a declared `O` (see <<metal>>).
+
+| Composition
+| Closes cleanly: nothing ∘ nothing = nothing.
+| Does *not* close cleanly (see `OND-ROADMAP.adoc` §5–6). The negative result
+  is first-class.
+
+| Required extra artifacts
+| None beyond the proof.
+| Two: a *declared observation model* (`O`, an input) and an enumerated
+  *residue list* (out-of-scope observables, an output).
+|===
+
+== Pillar I — CNO: certified null effect
+
+A *Certified Null Operation* is a program proven to have zero net
+computational effect. Formalised across six proof systems (Coq, Lean 4, Z3,
+Agda, Isabelle, Mizar), `is_CNO p` bundles four properties:
+
+1. *Termination* — `p` halts on every input.
+2. *Identity state map* — `eval p s = s` for all states `s`.
+3. *Functional purity* — no observable side effects: no I/O, no allocation.
+4. *Thermodynamic reversibility* — zero energy dissipation by Landauer's
+   principle (logical reversibility ⇒ no entropy increase, via Bennett).
+
+The defining feature of CNO is that *everything it talks about is inside the
+model*. State is a modelled object; "the output state equals the input state"
+is a closed mathematical statement, provable without reference to any physical
+execution. This is why CNO has no "metal boundary": there is nothing left
+outside the proof.
+
+== Pillar II — OND: certified null disclosure
+
+An *Observational Null Operation* is a program proven to leak nothing about
+its secret input *through a declared observation model `O`*. Where CNO asks
+"did the world change?", OND asks "could an observer watching through `O`
+learn anything about the secret?".
+
+Formally, fix an observation model `O` — a function from an execution to the
+trace an observer can see (for example: total wall-clock time; output length;
+the sequence of memory-allocation sizes; the pattern of branch outcomes). An
+operation `p` is *observationally null with respect to `O`* when its trace is
+*constant over the secret*: for any two secrets `s1`, `s2` sharing the same
+public inputs, `O(run p s1) = O(run p s2)`. The observer, restricted to `O`,
+cannot distinguish `s1` from `s2`.
+
+The canonical positive example is a *constant-time, fixed-value write*: it
+always writes the same bytes to the same location in the same time, so under
+an `O` that observes timing and write-targets it discloses nothing — even
+though it *does* change state (and so is *not* a CNO).
+
+== The coupling dial — a unifying frame (FRAMING, NOT THEOREM)
+
+The two pillars are two settings on a single *coupling dial* between a thing
+and the trace it casts to an observer:
+
+* *CNO* witnesses the emptiness of the *effect channel* — the operation casts
+  no trace into the world's state.
+* *OND* certifies the emptiness of the *disclosure channel* — the operation
+  casts no *secret-dependent* trace into the observer's view.
+
+[IMPORTANT]
+====
+The coupling dial is *framing, not theorem*. It is a way to organise the work
+and to see why the two pillars belong together; it is *not itself something
+that is proved*, and no individual theorem in either pillar may be justified
+by appeal to "the dial". When the roadmap labels an item, the dial is never
+the warrant. Treat this section as a map, not a lemma.
+====
+
+== Independence — a first-class theorem (`is_CNO` ⊥ `is_OND O`)
+
+CNO and OND are *logically independent*: neither entails the other. This is
+the result that earns the two-pillar split (rather than presenting OND as a
+special case of CNO or vice versa), and it is stated and proved as a
+first-class theorem of the OND pillar (see `OND-ROADMAP.adoc`, obligation
+*OND-3*).
+
+[cols="2,1,1,3",options="header"]
+|===
+| Witness operation | CNO? | OND under `O`? | Why
+
+| Constant-result early-exit comparison
+  (e.g. `memcmp`-style, returns a fixed value, mutates nothing)
+| *Yes*
+| *No*
+| State is unchanged (CNO holds), but the operation exits early on the first
+  mismatching byte, so *timing* — which is in `O` — varies with the secret.
+  The secret leaks through the disclosure channel.
+
+| Constant-time fixed-value write
+  (always writes the same bytes to the same place in the same time)
+| *No*
+| *Yes*
+| The trace observable through `O` is constant over the secret (OND holds),
+  but the operation *changes state*, so it is not a CNO.
+|===
+
+Each row is a witness: the first shows `is_CNO p ∧ ¬ is_OND O p`, the second
+shows `is_OND O p ∧ ¬ is_CNO p`. Together they prove neither predicate implies
+the other.
+
+[[metal]]
+== The model-vs-metal boundary — the honest edge of OND
+
+This is the boundary the structure must build in, not paper over.
+
+CNO certifies state-equality *entirely within the formal model*, because state
+is in the model. OND cannot do the same, because the observables it must reason
+about — timing, electromagnetic emanation, power draw, cache state, network
+residue — *live at a layer the formalism does not natively reach*. So an OND
+proof can only ever certify "observable constant over secret *relative to the
+declared `O`*". Every OND theorem is therefore a *conditional*:
+
+[quote]
+____
+*IF* the real execution's observables are exactly those enumerated in `O`,
+*THEN* no secret leaks through `O`.
+____
+
+Discharging the antecedent — establishing that the real machine really does
+expose only the observables in `O`, and nothing more — is a *separate job*
+done by constant-time engineering, compiler discipline, and hardware
+measurement. *It is not done by the proof assistant.* The proof assistant
+discharges the *consequent*, given `O`.
+
+The structure makes this explicit with two required artifacts for *every* OND
+claim:
+
+* a *declared observation model* `O` (a required *input*): the explicit,
+  enumerated list of what the observer is assumed to see; and
+* an enumerated *residue list* (a required *output*): the observables that are
+  *deliberately out of scope* of `O` (e.g. "this proof says nothing about
+  power analysis, speculative-execution side channels, or DRAM row-buffer
+  timing").
+
+[IMPORTANT]
+====
+The residue list is the *formal specification of the gap between the proof and
+physical reality*. It is not an apology; it is the deliverable that tells an
+engineer exactly which channels they still own. An OND claim *without* a
+declared `O` and a residue list is not an OND claim. No OND proof may be read
+as a guarantee about physical execution that its declared `O` does not
+support.
+====
+
+== Why two pillars — and why co-equal
+
+Three reasons the pillars are siblings, not parent-and-child:
+
+1. *Different conserved quantity.* CNO conserves state; OND conserves the
+   secret→observable channel. Neither is a refinement of the other.
+2. *Independence* (proved): neither predicate entails the other.
+3. *Different relationship to reality.* CNO is fully in-model and has no
+   residue; OND is irreducibly conditional and always has a residue list.
+   This asymmetry is real and is surfaced honestly — it is *not* a defect of
+   OND, it is the precise statement of what an observational guarantee can and
+   cannot mean.
+
+A fourth point is investigated rather than asserted: *composition*. CNOs
+compose cleanly. ONDs may not — two operations each individually constant over
+the secret can, run together, expose a *joint* observable that leaks (the same
+shape as the "max-composition is unsound for quasi-identifiers" worry from the
+echo/residue work). The OND pillar therefore ships a *negative* composition
+result and a *conditional* positive one, never a clean composition theorem.
+See `OND-ROADMAP.adoc` §5–6.
+
+== Status honesty (shared discipline)
+
+Both pillars use the same honest status vocabulary. CNO already carries many
+openly `Admitted` proofs (see `PROOF-CLASSIFICATION.adoc`); OND launching with
+obligations outstanding is therefore *normal and expected*, not a regression.
+OND adds three labels CNO does not need, applied per obligation in the roadmap:
+
+* *framing* — organising narrative; proves nothing (e.g. the coupling dial).
+* *conditional* — proved relative to a declared `O`; carries a residue list.
+* *metal-discharged* — *not* a proof-assistant obligation at all; owed to
+  constant-time engineering / compilation / hardware measurement.
+
+Every OND claim is labelled `proven`, `Admitted` (obligation outstanding),
+`conditional`, `framing`, or `metal-discharged`, and never silently upgraded
+between them.
+
+== See also
+
+* `OND-ROADMAP.adoc` — the prioritised proof roadmap (per-obligation:
+  statement, prover, label, priority).
+* `OND-PILLAR-STRUCTURE.adoc` — the directory/module layout mirroring CNO,
+  plus the observation-model and residue artifacts.
+* `PROOF-CLASSIFICATION.adoc` — the CNO pillar's proof classification (the
+  honesty template OND mirrors).

--- a/proofs/observation-models/README.adoc
+++ b/proofs/observation-models/README.adoc
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+= Observation Models (OND proof INPUTS)
+:toc:
+
+An *observation model* `O` is the *required input* to every Observational Null
+Operation (OND) claim. It is the explicit, enumerated specification of *what an
+observer is assumed to be able to see* of an execution. The OND proof then
+shows that this observable trace is *constant over the secret* — i.e. the
+operation discloses nothing about its secret input *through `O`*.
+
+See `docs/TWO-PILLARS.adoc` and `docs/OND-ROADMAP.adoc` for the theory.
+
+== Why this is an input, not a derived fact
+
+An OND theorem is a *conditional*: "IF the real execution exposes only the
+observables in `O`, THEN no secret leaks through `O`." The proof assistant
+discharges the *consequent*; the *antecedent* — that the metal really exposes
+only `O` — is owed to constant-time engineering, compilation, and hardware
+measurement (see `../residue/`). So `O` must be *declared up front*, not
+discovered: it fixes exactly what the proof is, and is not, about.
+
+== What goes in an observation model
+
+* The *observer's view*: each channel the observer is assumed to see (e.g.
+  total wall-clock time, output length, the sequence of allocation sizes, the
+  branch-outcome pattern, syscall trace).
+* The *secret / public split*: which inputs are secret (the proof quantifies
+  over them) and which are public (held fixed).
+* The *granularity*: e.g. "time to instruction-count resolution", "length in
+  bytes", so the trace equality is unambiguous.
+* *Explicitly excluded* channels are NOT listed here — they go in the matching
+  residue list under `../residue/`.
+
+== Conventions
+
+* One file per OND claim (or per operation/platform family), named for the
+  operation, e.g. `constant-time-select.adoc`, `wasm32-timing.adoc`.
+* Copy `TEMPLATE.adoc` to start.
+* Each declared `O` must have a *matching residue list* in `../residue/` with
+  the same base name.
+* `O` is referenced by name from the prover module that proves the claim (see
+  `docs/OND-PILLAR-STRUCTURE.adoc`).

--- a/proofs/observation-models/TEMPLATE.adoc
+++ b/proofs/observation-models/TEMPLATE.adoc
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+= Observation Model: <OPERATION NAME>
+// Copy this file to <operation-name>.adoc and fill every field.
+// There MUST be a matching residue list at ../residue/<operation-name>.adoc.
+
+== Operation under claim
+<What operation is this `O` for? One sentence. Link the prover module that
+proves `is_OND O <op>`.>
+
+== Secret / public split
+* *Secret* (proof quantifies over these): <e.g. the comparison key, the
+  branch condition>
+* *Public* (held fixed): <e.g. buffer length, alignment>
+
+== Observer's view (the channels in `O`)
+List every channel the observer is assumed to see, with granularity. The OND
+proof shows the trace over THESE channels is constant over the secret.
+
+[cols="2,3",options="header"]
+|===
+| Channel | Granularity / definition
+| <e.g. wall-clock time>     | <e.g. instruction-count resolution>
+| <e.g. output length>       | <e.g. bytes>
+| <e.g. allocation sizes>    | <e.g. ordered list of malloc sizes>
+| ...                        | ...
+|===
+
+== Trace equality obligation (the consequent the proof discharges)
+For all secrets `s1, s2` (with the public inputs fixed):
+`O(run <op> (s1, pub)) = O(run <op> (s2, pub))`.
+
+== Antecedent (owed to the metal — NOT proved here)
+State what must hold of the real execution for this `O` to be faithful (e.g.
+"the compiler emits branch-free code for the secret-dependent select", "no
+secret-dependent memory access"). This is discharged by engineering, not the
+proof assistant. The out-of-scope channels are enumerated in the matching
+residue list at `../residue/<operation-name>.adoc`.
+
+== Status
+<one of: proven (conditional on O) | Admitted (obligation outstanding) |
+draft>

--- a/proofs/residue/README.adoc
+++ b/proofs/residue/README.adoc
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+= Residue Lists (OND proof OUTPUTS / the model-vs-metal gap)
+:toc:
+
+A *residue list* is the *required output* of every Observational Null
+Operation (OND) claim: the enumerated set of observables that are
+*deliberately out of scope* of that claim's observation model `O`. It is the
+*formal specification of the gap between the proof and physical reality*.
+
+See `docs/TWO-PILLARS.adoc` §"model-vs-metal boundary" and `docs/OND-ROADMAP.adoc`
+obligation OND-7.
+
+== Why every OND claim must ship one
+
+An OND proof certifies "constant over the secret *relative to `O`*". Anything
+the real machine leaks that is *not* in `O` is, by construction, *not* covered.
+The residue list makes that uncovered surface *explicit and auditable* rather
+than silent. It is not an apology — it is the deliverable that tells an
+engineer exactly which channels they still own and must close on the metal.
+
+An OND claim *without* a residue list is not an OND claim.
+
+== What goes in a residue list
+
+For each out-of-scope channel:
+
+* *Channel* — the observable not covered (e.g. power draw, EM emanation,
+  speculative-execution / Spectre-class channels, DRAM row-buffer timing,
+  cache-line eviction patterns, microarchitectural port contention).
+* *Why excluded* — not in `O`; below the formalism's layer; platform-specific;
+  out of threat model.
+* *Who discharges it* — which engineering / measurement activity owns closing
+  it (constant-time codegen, hardware countermeasure, physical shielding), if
+  any.
+
+== Conventions
+
+* One file per OND claim, same base name as its observation model in
+  `../observation-models/`.
+* Copy `TEMPLATE.adoc` to start.
+* The residue list is a *living* document (OND-7): update it whenever `O`
+  changes or a new channel is recognised.
+* Collectively, the files here are the project's standing register of the
+  proof↔reality gap across all OND claims.

--- a/proofs/residue/TEMPLATE.adoc
+++ b/proofs/residue/TEMPLATE.adoc
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+= Residue List: <OPERATION NAME>
+// Copy this file to <operation-name>.adoc (same base name as the matching
+// observation model at ../observation-models/<operation-name>.adoc).
+
+== Claim this residue belongs to
+<Which OND claim? Link the observation model and the prover module.>
+
+== Observables OUT OF SCOPE of this claim's `O`
+Everything the real machine may leak that the proof does NOT cover.
+
+[cols="2,2,2",options="header"]
+|===
+| Channel (residue) | Why out of scope | Who discharges it (if anyone)
+| <e.g. power analysis>        | not in `O`; below formalism layer | hardware countermeasure
+| <e.g. speculative execution> | out of threat model                | compiler / mitigations
+| <e.g. EM emanation>          | physical layer                     | shielding
+| <e.g. DRAM row-buffer timing>| microarchitectural                 | (open / unowned)
+| ...                          | ...                                | ...
+|===
+
+== Honest summary
+<One or two sentences an engineer can act on: "This proof guarantees X
+relative to O. It says NOTHING about <residue>. To rely on it physically you
+must additionally close <residue> by <means>.">
+
+== Status
+<one of: current | needs-review (O changed) | draft>


### PR DESCRIPTION
## Summary

Adds **Observational Null Operations (OND)** as a **co-equal second pillar** to Absolute Zero, alongside the existing CNO (Certified Null *Effect*) pillar. **Design + documentation only — no proofs are started** (OND obligations are specified for a dedicated proof effort and are all currently `Admitted`, mirroring CNO's open-obligation culture).

OND certifies that an operation *reveals nothing about its secret input* relative to a **declared observation model `O`** — where CNO certifies it *does nothing to the world*.

## What's included

- **`docs/TWO-PILLARS.adoc`** — narrative spine: the two conserved quantities (state vs the secret→observable channel); the coupling-dial frame (*framing, not theorem*); the **CNO ⊥ OND independence** result with witnesses; the **model-vs-metal boundary** as OND's honest edge (declared `O` = required input; residue list = required output = formal spec of the proof↔reality gap).
- **`docs/OND-ROADMAP.adoc`** — prioritised obligations **OND-1..7** (statement / prover(s) / honesty label / priority), with an explicit critique + reorder of the proposed ordering and a **composition deep-dive**.
- **`docs/OND-PILLAR-STRUCTURE.adoc`** — per-prover module layout mirroring CNO + the two OND-specific artifact trees.
- **`proofs/observation-models/`** + **`proofs/residue/`** — templates for the declared-`O` and residue-list artifacts (proof inputs/outputs, not proofs).
- **`README.adoc`** + **`ROADMAP.adoc`** — threaded to present both pillars co-equally.

## Key design decisions

- **Independence is a first-class theorem** (OND-3), not framing — it earns the two-pillar split.
- **Composition does *not* close cleanly.** Ships a **negative result** (OND-5) + a **conditional positive** (OND-6); naive union-composition is unsound (state-chaining + emergent boundary observables — the DP sequential-composition / quasi-identifier shape). If a future effort claims clean composition, that is the claim to check hardest.
- **Priority reorder** vs the proposed (i)–(vi): trivial-case moved up to #2 (satisfiability smoke-test); the model-vs-metal discipline folded into the definition (#1) + per-claim template (#4) + ongoing register (#7); composition split into cheap-negative (#5, early) + hard-conditional (#6, last).

## Scope / honesty

No proofs written; all OND obligations are `Admitted`. The coupling dial is explicitly *framing*, never a warrant for any theorem. Authoring the OND proofs is deferred to a dedicated effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019awZjBD1qx61tvmEuEKNpn

---
_Generated by [Claude Code](https://claude.ai/code/session_019awZjBD1qx61tvmEuEKNpn)_